### PR TITLE
fix(build): set runtimeVersion policy for EAS Update

### DIFF
--- a/client/app.json
+++ b/client/app.json
@@ -4,6 +4,9 @@
     "slug": "toodaloo",
     "version": "1.0.0",
     "sdkVersion": "55.0.0",
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
     "icon": "./assets/icon.png",


### PR DESCRIPTION
## Summary

Unblocks OTA deploys. Adds `runtimeVersion.policy: "appVersion"` to \`client/app.json\`.

## Why

Discovered during /land-and-deploy on PR #4 that EAS Update was silently failing to publish:

\`\`\`
Error: Unable to determine runtime version for ios
Error: Unable to determine runtime version for android
\`\`\`

The \`main\` branch had **zero** updates ever published (\`eas update:list --branch main\` returned \`Could not find branch "main"\`), meaning every prior /land-and-deploy invocation hit this same wall silently. The code-merge side of the deploy pipeline has been working, but the OTA publish step has never run successfully because \`app.json\` had no \`runtimeVersion\` field and no policy to derive one.

## What this fixes

- EAS Update can now determine the runtime version for both iOS and Android builds
- Future \`eas update --branch main\` publishes will succeed
- /land-and-deploy's deploy step becomes functional instead of aspirational

## What this does NOT change

- No runtime behavior — this is a build-time config field only
- No impact on local dev workflow (\`npx expo start\` + Expo Go / simulator)
- No version bump needed (\`appVersion\` policy reads the existing \`version: "1.0.0"\`)
- No native rebuild required for current development

## Policy choice

\`appVersion\` was chosen over alternatives:
- ❌ \`sdkVersion\` — changes every SDK upgrade, forces runtime mismatches across minor Expo updates
- ❌ Hardcoded string — requires manual bumps, easy to forget
- ✅ \`appVersion\` — tied to the user-facing version number already in \`app.json\`, natural alignment with release semantics

All future EAS builds will be tagged with runtime version \`1.0.0\` and will receive OTA updates from \`main\` until the app version is bumped.

## Test plan

- [x] \`npx jest\` — 134/134 pass, 9 suites, 1.85s
- [x] JSON validity confirmed
- [ ] Post-merge: \`eas update:list --branch main\` returns the published update (instead of "Could not find branch")

🤖 Generated with [Claude Code](https://claude.com/claude-code)