### PR TITLE
docs: lowercase brand name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# TooDaLoo
+# toodaloo
 
 **Yelp for public bathrooms.** Find bathrooms near you, read and write reviews, and help others in need.
 
-TooDaLoo is a cross-platform mobile app built with Expo and React Native, backed by Supabase for auth and data.
+toodaloo is a cross-platform mobile app built with Expo and React Native, backed by Supabase for auth and data.
 
 ## Why
 
-When you're out in public and urgently need a bathroom, there's no reliable way to find one. TooDaLoo solves that with crowd-sourced, location-aware bathroom discovery.
+When you're out in public and urgently need a bathroom, there's no reliable way to find one. toodaloo solves that with crowd-sourced, location-aware bathroom discovery.
 
 ## Stack
 


### PR DESCRIPTION
## Summary
- Match README casing to the repository name (`toodaloo`)

## Test plan
- [x] README renders with lowercase brand name in all three places
- [ ] Claude PR reviewer runs and posts a summary comment (first-ever run of the workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)