### PR TITLE
security: SecureStore adapter for Supabase auth tokens

### DIFF
--- a/client/__tests__/context/UserContext.test.tsx
+++ b/client/__tests__/context/UserContext.test.tsx
@@ -24,6 +24,15 @@ jest.mock('../../lib/supabase', () => ({
   },
 }));
 
+jest.mock('../../lib/secureStorageAdapter', () => ({
+  migrateAuthStorageIfNeeded: jest.fn().mockResolvedValue(undefined),
+  secureStorageAdapter: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/client/context/UserContext.tsx
+++ b/client/context/UserContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { Session, User, AuthChangeEvent } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabase';
+import { migrateAuthStorageIfNeeded } from '../lib/secureStorageAdapter';
 
 type UserContextType = {
   session: Session | null;
@@ -22,11 +23,14 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // 1. Get current session on mount
-    supabase.auth.getSession().then(({ data: { session } }: { data: { session: Session | null } }) => {
-      setSession(session);
-      setUser(session?.user ?? null);
-      setLoading(false);
+    // 1. Migrate auth storage from AsyncStorage → SecureStore (one-time, non-fatal)
+    // then get current session on mount
+    migrateAuthStorageIfNeeded(process.env.EXPO_PUBLIC_SUPABASE_URL!).finally(() => {
+      supabase.auth.getSession().then(({ data: { session } }: { data: { session: Session | null } }) => {
+        setSession(session);
+        setUser(session?.user ?? null);
+        setLoading(false);
+      });
     });
 
     // 2. Subscribe to auth state changes

--- a/client/lib/secureStorageAdapter.ts
+++ b/client/lib/secureStorageAdapter.ts
@@ -1,0 +1,117 @@
+import { Platform } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const CHUNK_SIZE = 1800;
+
+function sanitizeKey(key: string): string {
+  return key.replace(/[^a-zA-Z0-9\-.]/g, '-').slice(0, 255);
+}
+
+// --- Web fallback (localStorage) ---
+const webAdapter = {
+  getItem: (key: string): string | null => {
+    try {
+      return localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  },
+  setItem: (key: string, value: string): void => {
+    try {
+      localStorage.setItem(key, value);
+    } catch {}
+  },
+  removeItem: (key: string): void => {
+    try {
+      localStorage.removeItem(key);
+    } catch {}
+  },
+};
+
+// --- Native adapter with chunking ---
+const nativeAdapter = {
+  getItem: async (key: string): Promise<string | null> => {
+    const sk = sanitizeKey(key);
+    const chunkCountStr = await SecureStore.getItemAsync(`${sk}.chunks`);
+    if (chunkCountStr === null) {
+      return SecureStore.getItemAsync(sk);
+    }
+    const chunkCount = parseInt(chunkCountStr, 10);
+    const chunks: string[] = [];
+    for (let i = 0; i < chunkCount; i++) {
+      const chunk = await SecureStore.getItemAsync(`${sk}.chunk.${i}`);
+      if (chunk === null) return null;
+      chunks.push(chunk);
+    }
+    return chunks.join('');
+  },
+
+  setItem: async (key: string, value: string): Promise<void> => {
+    const sk = sanitizeKey(key);
+    if (value.length <= CHUNK_SIZE) {
+      await SecureStore.setItemAsync(sk, value);
+      // Clean up any old chunks from a previous large value
+      await SecureStore.deleteItemAsync(`${sk}.chunks`).catch(() => {});
+    } else {
+      const chunkCount = Math.ceil(value.length / CHUNK_SIZE);
+      for (let i = 0; i < chunkCount; i++) {
+        await SecureStore.setItemAsync(
+          `${sk}.chunk.${i}`,
+          value.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE)
+        );
+      }
+      await SecureStore.setItemAsync(`${sk}.chunks`, String(chunkCount));
+      // Clean up any old non-chunked entry
+      await SecureStore.deleteItemAsync(sk).catch(() => {});
+    }
+  },
+
+  removeItem: async (key: string): Promise<void> => {
+    const sk = sanitizeKey(key);
+    await SecureStore.deleteItemAsync(sk).catch(() => {});
+    const chunkCountStr = await SecureStore.getItemAsync(`${sk}.chunks`);
+    if (chunkCountStr !== null) {
+      const chunkCount = parseInt(chunkCountStr, 10);
+      for (let i = 0; i < chunkCount; i++) {
+        await SecureStore.deleteItemAsync(`${sk}.chunk.${i}`).catch(() => {});
+      }
+      await SecureStore.deleteItemAsync(`${sk}.chunks`).catch(() => {});
+    }
+  },
+};
+
+// --- One-time migration from AsyncStorage → SecureStore ---
+// Runs once on native after an update. Users with existing sessions stored
+// in AsyncStorage will have them transparently migrated instead of being
+// silently logged out.
+export async function migrateAuthStorageIfNeeded(supabaseUrl: string): Promise<void> {
+  if (Platform.OS === 'web') return;
+
+  try {
+    // Derive the Supabase storage key from the project URL
+    // Supabase key format: sb-<project-ref>-auth-token
+    const projectRef = supabaseUrl.replace('https://', '').split('.')[0];
+    const legacyKey = `sb-${projectRef}-auth-token`;
+
+    const legacyValue = await AsyncStorage.getItem(legacyKey);
+    if (legacyValue === null) return; // Nothing to migrate
+
+    // Check if SecureStore already has this key (migration already ran)
+    const sk = sanitizeKey(legacyKey);
+    const existing = await SecureStore.getItemAsync(sk);
+    if (existing !== null) {
+      // Already migrated — clean up AsyncStorage copy
+      await AsyncStorage.removeItem(legacyKey);
+      return;
+    }
+
+    // Migrate: write to SecureStore, then remove from AsyncStorage
+    await nativeAdapter.setItem(legacyKey, legacyValue);
+    await AsyncStorage.removeItem(legacyKey);
+  } catch {
+    // Migration failure is non-fatal — user will just need to re-authenticate
+  }
+}
+
+export const secureStorageAdapter = Platform.OS === 'web' ? webAdapter : nativeAdapter;

--- a/client/lib/supabase.ts
+++ b/client/lib/supabase.ts
@@ -3,7 +3,7 @@
 //   npx expo install @react-native-async-storage/async-storage
 
 import { createClient } from '@supabase/supabase-js';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { secureStorageAdapter } from './secureStorageAdapter';
 
 // Replace these with your actual Supabase project values
 // Found at: https://app.supabase.com → Project Settings → API
@@ -12,7 +12,7 @@ const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? 'YOUR_SUP
 
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: {
-    storage: AsyncStorage,
+    storage: secureStorageAdapter,
     autoRefreshToken: true,
     persistSession: true,
     detectSessionInUrl: false,


### PR DESCRIPTION
## Summary
- Install `expo-secure-store` and implement a chunked SecureStore adapter for Supabase session persistence
- Web fallback uses `localStorage` (native `SecureStore` doesn't exist on web)
- One-time migration from `AsyncStorage` → `SecureStore` on first launch, so existing sessions aren't silently invalidated
- Swap `AsyncStorage` for the new adapter in `createClient` options
- Wire `migrateAuthStorageIfNeeded` into `UserContext` before `getSession`
- Fix `app.json` `runtimeVersion` (see #7 for context — same commit, auto-dedupes on merge)

## Why
From the React Native audit against `expo:native-data-fetching`:
- Auth tokens should never be stored in `AsyncStorage` — it is unencrypted and accessible on jailbroken/rooted devices
- `expo-secure-store` writes to iOS Keychain / Android Keystore, which is the appropriate trust boundary for credentials

## Implementation details
**`lib/secureStorageAdapter.ts` (new file):**
- `sanitizeKey` replaces non-`[a-zA-Z0-9\-.]` chars with `-` (Supabase keys contain colons, SecureStore doesn't allow them)
- **Chunking**: values larger than 1800 bytes are split across `key.chunk.0`, `key.chunk.1`, ..., with a `key.chunks` metadata entry holding the chunk count. Necessary because Supabase session JSON (two JWTs + user metadata) commonly exceeds SecureStore's ~2KB limit
- **Migration** (`migrateAuthStorageIfNeeded`): reads the legacy `sb-<project-ref>-auth-token` key from AsyncStorage, writes it to SecureStore via the chunking adapter, then deletes the AsyncStorage copy. Idempotent — skips if already migrated. Wrapped in try/catch so a migration failure never blocks app startup
- **Web fallback**: `Platform.OS === 'web' ? localStorageAdapter : secureStoreAdapter`

**`lib/supabase.ts`:** single surgical change — swap `storage: AsyncStorage` for `storage: secureStorageAdapter`

**`context/UserContext.tsx`:** `migrateAuthStorageIfNeeded(process.env.EXPO_PUBLIC_SUPABASE_URL!).finally(() => supabase.auth.getSession()...)` — guarantees migration completes before the first session read.

## Test plan
- [x] Sign in via OTP succeeds
- [x] Kill app, reopen — session auto-restores (proves SecureStore persistence works)
- [x] Sign out — session clears and does not persist on next open
- [ ] Manual check: verify existing user with AsyncStorage session stays logged in after this update lands (migration path)

## Note on native rebuild
`expo-secure-store` is a native module. A development client rebuild (`expo run:ios` / `expo run:android`) is required after this PR merges for consumers on dev clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)