### PR TITLE
perf(skeletons): migrate pulse animation to Reanimated worklets

### DIFF
--- a/client/components/SkeletonBathroomCard.tsx
+++ b/client/components/SkeletonBathroomCard.tsx
@@ -1,27 +1,12 @@
-import React, { useEffect, useRef } from 'react';
-import { Animated, View, StyleSheet } from 'react-native';
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import Animated from 'react-native-reanimated';
 import { useThemeContext } from '../context/ThemeContext';
+import { useSkeletonOpacity } from '../hooks/useSkeletonOpacity';
 
 export function SkeletonBathroomCard() {
   const { colors } = useThemeContext();
-  const opacity = useRef(new Animated.Value(0.4)).current;
-
-  useEffect(() => {
-    Animated.loop(
-      Animated.sequence([
-        Animated.timing(opacity, {
-          toValue: 0.9,
-          duration: 800,
-          useNativeDriver: true,
-        }),
-        Animated.timing(opacity, {
-          toValue: 0.4,
-          duration: 800,
-          useNativeDriver: true,
-        }),
-      ]),
-    ).start();
-  }, [opacity]);
+  const animatedStyle = useSkeletonOpacity();
 
   const shimmerStyle = {
     backgroundColor: colors.surface3,
@@ -35,8 +20,8 @@ export function SkeletonBathroomCard() {
         {
           backgroundColor: colors.surface2,
           borderColor: colors.border,
-          opacity,
         },
+        animatedStyle,
       ]}
     >
       {/* Emoji placeholder */}

--- a/client/components/SkeletonProfileHero.tsx
+++ b/client/components/SkeletonProfileHero.tsx
@@ -1,19 +1,12 @@
-import React, { useEffect, useRef } from 'react';
-import { Animated, View, StyleSheet } from 'react-native';
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import Animated from 'react-native-reanimated';
 import { useThemeContext } from '../context/ThemeContext';
+import { useSkeletonOpacity } from '../hooks/useSkeletonOpacity';
 
 export function SkeletonProfileHero() {
   const { colors } = useThemeContext();
-  const opacity = useRef(new Animated.Value(0.4)).current;
-
-  useEffect(() => {
-    Animated.loop(
-      Animated.sequence([
-        Animated.timing(opacity, { toValue: 0.9, duration: 800, useNativeDriver: true }),
-        Animated.timing(opacity, { toValue: 0.4, duration: 800, useNativeDriver: true }),
-      ]),
-    ).start();
-  }, [opacity]);
+  const animatedStyle = useSkeletonOpacity();
 
   const shimmer = { backgroundColor: colors.surface3, borderRadius: 6 };
 
@@ -25,8 +18,8 @@ export function SkeletonProfileHero() {
           backgroundColor: colors.surface1,
           borderBottomWidth: 1,
           borderBottomColor: colors.border,
-          opacity,
         },
+        animatedStyle,
       ]}
     >
       {/* Avatar circle */}

--- a/client/components/SkeletonReviewCard.tsx
+++ b/client/components/SkeletonReviewCard.tsx
@@ -1,19 +1,12 @@
-import React, { useEffect, useRef } from 'react';
-import { Animated, View, StyleSheet } from 'react-native';
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import Animated from 'react-native-reanimated';
 import { useThemeContext } from '../context/ThemeContext';
+import { useSkeletonOpacity } from '../hooks/useSkeletonOpacity';
 
 export function SkeletonReviewCard() {
   const { colors } = useThemeContext();
-  const opacity = useRef(new Animated.Value(0.4)).current;
-
-  useEffect(() => {
-    Animated.loop(
-      Animated.sequence([
-        Animated.timing(opacity, { toValue: 0.9, duration: 800, useNativeDriver: true }),
-        Animated.timing(opacity, { toValue: 0.4, duration: 800, useNativeDriver: true }),
-      ]),
-    ).start();
-  }, [opacity]);
+  const animatedStyle = useSkeletonOpacity();
 
   const shimmer = { backgroundColor: colors.surface3, borderRadius: 4 };
 
@@ -21,7 +14,8 @@ export function SkeletonReviewCard() {
     <Animated.View
       style={[
         styles.card,
-        { backgroundColor: colors.surface2, borderRadius: 14, opacity },
+        { backgroundColor: colors.surface2, borderRadius: 14 },
+        animatedStyle,
       ]}
     >
       {/* Header row: author + date */}

--- a/client/hooks/useSkeletonOpacity.ts
+++ b/client/hooks/useSkeletonOpacity.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import {
+  useSharedValue,
+  useAnimatedStyle,
+  useReducedMotion,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+
+interface Options {
+  minOpacity?: number;
+  maxOpacity?: number;
+  duration?: number;
+}
+
+export function useSkeletonOpacity({
+  minOpacity = 0.4,
+  maxOpacity = 0.9,
+  duration = 800,
+}: Options = {}) {
+  const opacity = useSharedValue(minOpacity);
+  const reducedMotion = useReducedMotion();
+
+  useEffect(() => {
+    if (reducedMotion) {
+      opacity.value = (minOpacity + maxOpacity) / 2;
+      return;
+    }
+    opacity.value = withRepeat(
+      withSequence(
+        withTiming(maxOpacity, { duration }),
+        withTiming(minOpacity, { duration }),
+      ),
+      -1,
+      false,
+    );
+  }, [opacity, minOpacity, maxOpacity, duration, reducedMotion]);
+
+  return useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
+}

--- a/client/hooks/useSkeletonOpacity.ts
+++ b/client/hooks/useSkeletonOpacity.ts
@@ -24,7 +24,7 @@ export function useSkeletonOpacity({
 
   useEffect(() => {
     if (reducedMotion) {
-      opacity.value = (minOpacity + maxOpacity) / 2;
+      opacity.value = maxOpacity;
       return;
     }
     opacity.value = withRepeat(


### PR DESCRIPTION
## Summary

- Migrates the 3 skeleton components (`SkeletonBathroomCard`, `SkeletonProfileHero`, `SkeletonReviewCard`) from JS-thread `Animated.Value` + `Animated.loop` to UI-thread Reanimated worklets via a new shared `useSkeletonOpacity` hook
- Extracts the byte-identical 0.4 → 0.9 → 0.4 @ 800ms pulse logic that was copy-pasted across all three files into a single configurable hook
- Honors the OS reduce-motion accessibility setting via `useReducedMotion`, pinning to max opacity (WCAG 2.3.3 — preserve information density while removing animation)

This is **PR A of a two-PR migration**. PR B will replace `BathroomSheet`'s `PanResponder` gesture with `@gorhom/bottom-sheet` (the larger surface).

## Why

Reanimated runs animation worklets on the UI thread instead of competing with React reconciliation and touch handling on the JS thread. The old `Animated.loop` pattern could hitch during heavy render work; the new implementation won't.

Bonus: −47 lines of duplicated animation boilerplate.

## Test plan

- [x] `npx jest` — 134/134 passing, including the 14 `BathroomSheet.test.tsx` tests (skeletons are mocked in that suite, so the migration is transparent to tests)
- [x] `npx tsc --noEmit` — clean (only pre-existing `jest-native/extend-expect` type def error, unrelated)
- [ ] Visual QA: verify the pulse still feels correct during loading states on the Map screen, the Saved tab, and the Profile screen
- [ ] Accessibility QA: enable iOS "Reduce Motion" in Settings and confirm the skeletons render at full brightness with no animation

## Review pipeline

Ran locally via `phase:review` — 3 parallel agents (reuse, quality, efficiency) + the `vercel-react-native-skills` rule set. One finding auto-fixed (reduce-motion opacity pinned to max instead of midpoint for better WCAG information density). No critical findings. Efficiency agent verified against `react-native-reanimated/src/hook/useSharedValue.ts` that `cancelAnimation` is installed as an unmount cleanup — no leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)